### PR TITLE
Print useful IP information during tests

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -31,6 +31,10 @@ check_os() {
     esac
 }
 
+check_ip() {
+  run curl -4 --write-out "\n" ifconfig.co/json 
+}
+
 dig_short() {
     output="$(dig +short "$@")"
     if [ -z "$output" ]; then
@@ -82,6 +86,7 @@ gethostbyname() {
 
 auto_test_all() {
     check os
+    check ip
     check dns
     check ping
     check route

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -61,8 +61,12 @@ check_ping() {
     run ping -c 10 api.stripe.com
 }
 
-check_mtr() {
-    run mtr -n --report api.stripe.com
+check_route() {
+    if command -v mtr 2>/dev/null; then
+        run mtr -n --report api.stripe.com
+    elif command -v traceroute 2>/dev/null; then
+        run traceroute -n -m 20 api.stripe.com
+    fi
 }
 
 check_curl_http() {
@@ -80,7 +84,7 @@ auto_test_all() {
     check os
     check dns
     check ping
-    check mtr
+    check route
     check curl_http
     check curl_https
 }

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -47,6 +47,8 @@ check_dns() {
 
     from_local="$(gethostbyname api.stripe.com)"
 
+    echo "api.stripe.com IP: $from_local"
+    echo "api.stripe.com nameservers: $stripe_ns"
     if ! grep -x "$from_local" <<< "$api_addresses" >/dev/null; then
         echo "Error: mismatch between resolved api.stripe.com addresses"
         echo "gethostbyname: $from_local"


### PR DESCRIPTION
Each commit is standalone. We now print DNS and IP info during the hostname lookup, we fail back to traceroute when mtr isn't installed and we ask ifconfig.co for a location information, along with the client IP.

r? @dougbarth-stripe since you asked :)